### PR TITLE
Add logIndex to TransferSentToL2 event

### DIFF
--- a/L1_Bridge_schema.graphql
+++ b/L1_Bridge_schema.graphql
@@ -185,6 +185,7 @@ type TransferSentToL2 @entity {
   block: Block!
   transaction: Transaction!
   tokenEntity: Token!
+  logIndex: BigInt!
 
   # legacy
   transactionHash: String!

--- a/src/L1_mapping.template.ts
+++ b/src/L1_mapping.template.ts
@@ -264,6 +264,7 @@ export function handleTransferSentToL2(event: TransferSentToL2): void {
   entity.block = event.params._event.block.hash.toHexString()
   entity.transaction = event.params._event.transaction.hash.toHexString()
   entity.tokenEntity = TOKEN_ADDRESS
+  entity.logIndex = event.params._event.logIndex
 
   // legacy
   entity.transactionHash = event.params._event.transaction.hash.toHexString()


### PR DESCRIPTION
Transfers sent from L1 -> L2 do not have a `transferNonce` like L2 -> any do. The only way (I believe) to observe uniqueness is to include _both_ `txHash` and `logIndex` (if a user sends multiple `sendToL2s` in a single tx, the `logIndex` will need to be used).

The hop-node has been modified to account for this, but TheGraph needs to expose this for additional functionality, such as the HealthChecker. This is already building [here](https://thegraph.com/hosted-service/subgraph/hop-protocol/hop-mainnet?version=pending) but just wanted another pair of eyes to makes sure this lines up with what you would expect.

As a note, TheGraph entities have a concept of `event.transactionLogIndex` and `event.params._event.logIndex`. IIUC, `event.transactionLogIndex` is the index of the event _within the tx_ (i.e. if there were 3 `sendToL2` events, then the `transactionLogIndex` for each would be 0, 1, 2). The `event.params._event.logIndex` corresponds to the index of the event _within the block_ (i.e. it would be `340` for [this](https://etherscan.io/tx/0x24d3c157f683fbbae9934eb8028717679921fdf20f73f671152271f8f3f8e190#eventlog) tx). I believe we need to use `event.params._event.logIndex` because (1) RPC nodes do not support `event.transactionLogIndex` (I'm actually not sure how TheGraph does it), and (2) we do not have access to `event.transactionLogIndex` at the HopNode level.